### PR TITLE
Add buffdebuff component

### DIFF
--- a/src/components/mdx/BuffDebuff.astro
+++ b/src/components/mdx/BuffDebuff.astro
@@ -1,0 +1,11 @@
+---
+import { Image } from 'astro:assets';
+
+const props = Astro.props;
+
+interface Props {
+  name?: string;
+  img?: ImageMetadata;
+}
+---
+<Image class="buffdebuff" src={props.img} alt={props.name} /><i>{props.name}</i>

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -157,3 +157,8 @@
     @apply p-4 rounded mb-4;
   }
 }
+
+.buffdebuff {
+  display: inline;
+  max-inline-size: 1em;
+}


### PR DESCRIPTION
Adds a component for an icon + buff/debuff name combo
![image](https://github.com/user-attachments/assets/7f25c6b3-7af5-4fd8-b695-fde7fee413a7)
```mdx
import slashing from '../assets/icons/slashing.png'
import BuffDebuff from '@/components/mdx/BuffDebuff.astro'

<BuffDebuff name="Slashing Resistance Down II" img={slashing} />
```