### PR TITLE
Update buffdebuff vertical alignment

### DIFF
--- a/src/components/mdx/BuffDebuff.astro
+++ b/src/components/mdx/BuffDebuff.astro
@@ -8,4 +8,4 @@ interface Props {
   img?: ImageMetadata;
 }
 ---
-<Image class="buffdebuff" src={props.img} alt={props.name} /><i>{props.name}</i>
+<Image class="buffdebuff" src={props.img} alt="" /><i>{props.name}</i>

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -161,4 +161,5 @@
 .buffdebuff {
   display: inline;
   max-inline-size: 1em;
+  vertical-align: text-bottom;
 }


### PR DESCRIPTION
The more I looked at it the more it bugged me
Before:
![image](https://github.com/user-attachments/assets/8d4608a9-8f00-4309-8a0c-d758b5735d2c)
After:
![image](https://github.com/user-attachments/assets/e1d20d5f-f325-468a-8203-2ebeee919edd)

Also removes alt text cause when copying paragraphs it'd result in 
`Additionally, if the person who intercepted the orb does not have the NeurolinkNeurolink debuff`
instead of 
`Additionally, if the person who intercepted the orb does not have the Neurolink debuff`