### PR TITLE
Clean up twin.mdx

### DIFF
--- a/src/components/mdx/Status.astro
+++ b/src/components/mdx/Status.astro
@@ -8,4 +8,4 @@ interface Props {
   img?: ImageMetadata;
 }
 ---
-<Image class="buffdebuff" src={props.img} alt="" /><i>{props.name}</i>
+<Image class="status" src={props.img} alt="" /><i>{props.name}</i>

--- a/src/pages/twin.mdx
+++ b/src/pages/twin.mdx
@@ -5,6 +5,7 @@ nav_order: 2
 show_toc: false
 ---
 
+{/* Components */}
 import Notification from '@/components/mdx/Notification.astro'
 import Button from '@/components/mdx/Button.astro'
 import Status from '@/components/mdx/Status.astro'
@@ -14,12 +15,14 @@ import { YouTube } from 'astro-embed'
 import ImageWrapper from '@/components/mdx/ImageWrapper.astro'
 import ImageWrapperSquare from '@/components/mdx/ImageWrapperSquare.astro'
 
+{/* Images */}
 import neurolinkpuddle from '../assets/images/neurolink-puddle.png'
 import twister from '../assets/images/twister.png'
 import fireball from '../assets/images/fireball.png'
 import hatchresolve from '../assets/images/hatch-resolve-side.png'
 import hatchmarker from '../assets/images/hatch-and-marker.png'
 
+{/* Statuses */}
 import slashing from '../assets/icons/slashing.png'
 import damagedown from '../assets/icons/damagedown.png'
 import neurolink from '../assets/icons/neurolink.png'

--- a/src/pages/twin.mdx
+++ b/src/pages/twin.mdx
@@ -37,7 +37,8 @@ import manahyper from '../assets/icons/manahyper.png'
 <Notification title="NA strat tl;dr">
     Neurolink placement - Normal triangle: N, SW, SE (CCW, on 123 markers)  
     Both tanks and 1 healer (discuss) stay out of first stack for LB cheese  
-    Phys. range always baits liquid hells, caster intercepts hatch if phys. range is first hatch
+    Phys. range always baits liquid hells, caster intercepts hatch if phys. 
+    range is first hatch
 </Notification>
 
 
@@ -207,9 +208,9 @@ into the Neurolink directly towards the Hatch in this phase.
     (**caster**) intercept the Hatch for the baiter.  
     
     In conjunction with baiting Liquid Hells, positioning for this correctly
-    without causing a death or wipe can be tricky. Use
-    [this raidplan](https://raidplan.io/plan/19yavfslOUU0l1Gp) or check out
-    this useful video that will help you prepare for this!
+    without causing a death or wipe can be tricky. Use [this
+    raidplan](https://raidplan.io/plan/19yavfslOUU0l1Gp) or check out this
+    useful video that will help you prepare for this!
     <YouTube id="9DDTla_pbL0" />
 </NASpecific>
 

--- a/src/pages/twin.mdx
+++ b/src/pages/twin.mdx
@@ -5,7 +5,6 @@ nav_order: 2
 show_toc: false
 ---
 
-import { Image } from 'astro:assets'
 import Notification from '@/components/mdx/Notification.astro'
 import Button from '@/components/mdx/Button.astro'
 import BuffDebuff from '@/components/mdx/BuffDebuff.astro'
@@ -60,7 +59,7 @@ explained later in this page.
 
 <NASpecific>
 The Neurolink puddles will need to be spread out for the resolution of mechanics in this phase and future phases.
-NA drops these puddles in a counter-clockwise order, starting from North to Southwest to Southeast. If you're using
+NA drops these puddles in a counter-clockwise order, starting from North to Southwest to Southeast. If you&apos;re using
 the recommended markers, it is on the 1, 2, and 3 markers, in order.
 </NASpecific>
 

--- a/src/pages/twin.mdx
+++ b/src/pages/twin.mdx
@@ -40,11 +40,13 @@ import manahyper from '../assets/icons/manahyper.png'
     Phys. range always baits liquid hells, caster intercepts hatch if phys. range is first hatch
 </Notification>
 
+
 ## Overview
 [Overall Raidplan](https://raidplan.io/plan/9WEG4AEGVdru3hyF)  
-Twintania has 3 separate mini-phases, governed by HP thresholds,
-which dictate the mechanic loop that Twintania executes. These HP
-thresholds are:  
+Twintania has 3 separate mini-phases, governed by HP thresholds, which dictate
+the mechanic loop that Twintania executes.
+
+These HP thresholds are:  
 <Button class="btn btn-primary-light" href="#h-hp-threshold-1-100-75">100%-75%</Button>
 <Button class="btn btn-secondary-light" href="#h-hp-threshold-2-749-45">74.9%-45%</Button>
 <Button class="btn btn-highlighter" href="#hp-threshold-3-449-01">44.9%-0.1%</Button>  
@@ -52,15 +54,16 @@ thresholds are:
 <ImageWrapperSquare img={neurolinkpuddle} alt="Neurolink puddle" classdiv="mt-8"/>
 **Neurolink** - Small puddle that is dropped under the center of Twintania's hitbox
 upon hitting a HP threshold  
-When a player steps into the Neurolink, the player gets
-a <BuffDebuff name="Neurolink" img={neurolink} /> debuff, which reduces damage done by approximately 90% and
-healing done by approximately 10%. This debuff will be required to resolve the **Generate** mechanic
-explained later in this page.  
+When a player steps into the Neurolink, the player gets a <BuffDebuff
+name="Neurolink" img={neurolink} /> debuff, which reduces damage done by
+approximately 90% and healing done by approximately 10%. This debuff will be
+required to resolve the **Generate** mechanic explained later in this page.  
 
 <NASpecific>
-The Neurolink puddles will need to be spread out for the resolution of mechanics in this phase and future phases.
-NA drops these puddles in a counter-clockwise order, starting from North to Southwest to Southeast. If you&apos;re using
-the recommended markers, it is on the 1, 2, and 3 markers, in order.
+The Neurolink puddles will need to be spread out for the resolution of mechanics
+in this phase and future phases. NA drops these puddles in a counter-clockwise
+order, starting from North to Southwest to Southeast. If you&apos;re using the
+recommended markers, it is on the 1, 2, and 3 markers, in order.
 </NASpecific>
 
 
@@ -76,32 +79,38 @@ the recommended markers, it is on the 1, 2, and 3 markers, in order.
     - Fireball
 </Card>
 
-- **Plummet** - Conal physical mini-tankbuster aimed at the player that is highest in aggro, no cast time  
+- **Plummet** - Conal physical mini-tankbuster aimed at the player that is
+  highest in aggro, no cast time  
 
 
 <ImageWrapperSquare img={twister} alt="Twister" classdiv="mt-8"/>
 
-- **Twister** - Drops small tornadoes (Twisters) under 4 players near the end of the cast  
-If a player touches a Twister, it will immediately kill the player who touched the Twister. Additionally,
-any players within the vicinity of the Twister will take lethal damage and be knocked back into the wall.
-Dodge Twisters by moving away from your initial position at about 75% of the cast till the cast ends (Latency
-dependent).
+- **Twister** - Drops small tornadoes (Twisters) under 4 players near the end of
+  the cast  
+If a player touches a Twister, it will immediately kill the player who touched
+the Twister. Additionally, any players within the vicinity of the Twister will
+take lethal damage and be knocked back into the wall. Dodge Twisters by moving
+away from your initial position at about 75% of the cast till the cast ends
+(Latency dependent).
 
 
 <ImageWrapperSquare img={fireball} alt="Fireball marker" classdiv="mt-8"/>
 
 - **Fireball** - Targeted party stack on marked player  
-It is common to 5 stack the Fireball in the opener with 4 DPS and 1 healer to generate LB for a future phase. 
-Both tanks and 1 healer (discuss with your party) will stay out of this initial stack. Subsequent Fireball stacks
-should be stacked with as many people as possible.[^1]
+It is common to 5 stack the Fireball in the opener with 4 DPS and 1 healer to
+generate LB for a future phase. Both tanks and 1 healer (discuss with your
+party) will stay out of this initial stack. Subsequent Fireball stacks should be
+stacked with as many people as possible.[^1]
   
-- **Death Sentence** - Tankbuster (Forced tankswap) which inflicts 
+- **Death Sentence** - Tankbuster (Forced tankswap) which inflicts
 a <BuffDebuff name="Slashing Resistance Down II" img={slashing} /> on the target  
-Forced swap as Twintania's autos are slashing type. If the player that currently has 
-the <BuffDebuff name="Slashing Resistance Down II" img={slashing} /> takes an auto, they will take lethal
-damage.  
+Forced swap as Twintania's autos are slashing type. If the player that currently
+has the <BuffDebuff name="Slashing Resistance Down II" img={slashing} /> takes
+an auto, they will take lethal damage.  
 
-Most parties will usually hit the next HP threshold after the Death Sentence or 2nd Plummet in the loop.
+Most parties will usually hit the next HP threshold after the Death Sentence or
+2nd Plummet in the loop.
+
 
 ### HP Threshold 2 (74.9%-45%)
 <Card title="Mechanic Loop">
@@ -114,31 +123,39 @@ Most parties will usually hit the next HP threshold after the Death Sentence or 
     - Plummet
 </Card>
 
-- **Liquid Hells** - A set of 5x puddles, baited sequentially on the targeted player  
-Each puddle is a moderately-sized circle which applies <BuffDebuff name="Burns" img={burns} />, a lethal DoT,
-to any players who stand in the puddle for too long.  
-The targeted player is any single player that has a distance of at least 10 yalms from the boss. If there are multiple valid
-targets, a random player within the valid radius is chosen as the target for a single Liquid Hell.
+- **Liquid Hells** - A set of 5x puddles, baited sequentially on the targeted
+  player  
+Each puddle is a moderately-sized circle which applies <BuffDebuff name="Burns"img={burns} />,
+a lethal DoT, to any players who stand in the puddle for too long.  
+The targeted player is any single player that has a distance of at least 10
+yalms from the boss. If there are multiple valid targets, a random player within
+the valid radius is chosen as the target for a single Liquid Hell.
 
 <ImageWrapper img={hatchmarker} alt="The Hatch and its respective marker" classdiv="mt-8"/>
 
-- **Generate** - Marks 1-3 players for an orb that follows the location of the player till the orb is intercepted  
-An orb is also referred to as a **Hatch**. *In this phase*, only DPS players can get marked for a Hatch.
-The number of players marked is determined by the number of Neurolinks that are currently on the arena.  
-When an orb is intercepted, the orb will explode and deal lethal damage to players in the immediate vicinity who
-do not have the <BuffDebuff name="Neurolink" img={neurolink} /> debuff, attained from standing in a Neurolink.
-The people in the vicinity of the explosion who survive will 
-get <BuffDebuff name="Mana Hypersensitivity" img={manahyper} /> for 16 seconds, making any Hatch-related damage
-lethal during the duration of the debuff with or without the <BuffDebuff name="Neurolink" img={neurolink} /> debuff.   
-If the person who intercepted the orb dies, usually when they do not have
-the <BuffDebuff name="Neurolink" img={neurolink} />, the orb will further explode, dealing
-lethal raidwide damage and applying <BuffDebuff name="Damage Down" img={damagedown} /> to any surviving players.
-The same result will occur when nobody intercepts the orb when 10 seconds have passed since the end of the
+- **Generate** - Marks 1-3 players for an orb that follows the location of the
+  player till the orb is intercepted  
+An orb is also referred to as a **Hatch**. *In this phase*, only DPS players can
+get marked for a Hatch. The number of players marked is determined by the number
+of Neurolinks that are currently on the arena.  
+When an orb is intercepted, the orb will explode and deal lethal damage to
+players in the immediate vicinity who do not have the <BuffDebuff name="Neurolink" img={neurolink} />
+debuff, attained from standing in a Neurolink. The people in the vicinity of the
+explosion who survive will get <BuffDebuff name="Mana Hypersensitivity" img={manahyper} />
+for 16 seconds, making any Hatch-related damage lethal during the duration of
+the debuff with or without the <BuffDebuff name="Neurolink" img={neurolink} />
+debuff.   
+If the person who intercepted the orb dies, usually when they do not have the
+<BuffDebuff name="Neurolink" img={neurolink} />, the orb will further explode,
+dealing lethal raidwide damage and applying <BuffDebuff name="Damage Down"
+img={damagedown} /> to any surviving players. The same result will occur when
+nobody intercepts the orb when 10 seconds have passed since the end of the
 Generate cast.  
   
-The second set of Liquid Hells in this mechanic loop will happen ***during*** the resolution of the Hatch. 
-Likewise, the Twister in this set will happen during the resolution of the Hatch. See
-[the section on hatches](#hatches) for more info.
+The second set of Liquid Hells in this mechanic loop will happen ***during***
+the resolution of the Hatch. Likewise, the Twister in this set will happen
+during the resolution of the Hatch. See [the section on hatches](#hatches) for
+more info.
 
 
 ### HP Threshold 3 (44.9%-0.1%)
@@ -153,45 +170,54 @@ Likewise, the Twister in this set will happen during the resolution of the Hatch
     - Plummet  
 </Card>
 
-- **Liquid Hells (random)** - Same as Liquid Hells, but instead of a person past a certain range, it is
-a random single target for all 5 puddles.  
+- **Liquid Hells (random)** - Same as Liquid Hells, but instead of a person past
+a certain range, it is a random single target for all 5 puddles.  
   
   
 ## Role Breakdown and Tips
 ### Tank
-Take care to face the plummet away from the party or even rogue players that may be standing in the cleaved area.
+Take care to face the plummet away from the party or even rogue players that may
+be standing in the cleaved area.
 #### Positioning and Uptime 
 Tanks can do a lot to make the melee DPS' life a lot easier such as:
-- Standing where the other tank is standing when provoking from them, keeping the boss facing the same way
+- Standing where the other tank is standing when provoking from them, keeping
+  the boss facing the same way
 - Positioning Twintania closer to the Neurolinks temporarily.
 [HP Threshold 2 example](https://www.twitch.tv/videos/2149285444?t=0h0m38s) &
 [HP Threshold 3 example](https://www.twitch.tv/videos/2149278406?t=0h1m28s)
   
 
 ### Healer
-Some people may not stack for Fireball stacks, so be prepared to throw out a shield or mitigation.
+Some people may not stack for Fireball stacks, so be prepared to throw out a
+shield or mitigation.
   
 
 ### DPS
 #### Hatches
 <ImageWrapperSquare img={hatchresolve} alt="Hatch resolution from the side" />
-Since the <BuffDebuff name="Neurolink" img={neurolink} /> debuff reduces damage done by the player,
-minimizing the amount of time spent in the Neurolink to resolve Hatches is ideal. However, due to the way
-snapshots and latency work, it is recommended to **walk into the Neurolink from the side** instead of walking
+Since the <BuffDebuff name="Neurolink" img={neurolink} /> debuff reduces damage
+done by the player, minimizing the amount of time spent in the Neurolink to
+resolve Hatches is ideal. However, due to the way snapshots and latency work, it
+is recommended to **walk into the Neurolink from the side** instead of walking
 into the Neurolink directly towards the Hatch in this phase.
 
 <NASpecific>
-    For the Generate + Liquid Hell combo, if the Liquid Hell baiter (**physical ranged**) gets marked for a Hatch,
-    it is common to have someone else (**caster**) intercept the Hatch for the baiter.  
-    In conjunction with baiting Liquid Hells, positioning for this correctly without causing a death or wipe can be 
-    tricky. Use [this raidplan](https://raidplan.io/plan/19yavfslOUU0l1Gp) or check out this useful video that will
-    help you prepare for this!
+    For the Generate + Liquid Hell combo, if the Liquid Hell baiter (**physical
+    ranged**) gets marked for a Hatch, it is common to have someone else
+    (**caster**) intercept the Hatch for the baiter.  
+    
+    In conjunction with baiting Liquid Hells, positioning for this correctly
+    without causing a death or wipe can be tricky. Use
+    [this raidplan](https://raidplan.io/plan/19yavfslOUU0l1Gp) or check out
+    this useful video that will help you prepare for this!
     <YouTube id="9DDTla_pbL0" />
 </NASpecific>
 
-For the Generate + Twister combo, Twister will usually go off before the orb reaches you. Make sure you drop
-the twister outside of the Neurolink to ensure your end position is safe.
+For the Generate + Twister combo, Twister will usually go off before the orb
+reaches you. Make sure you drop the twister outside of the Neurolink to ensure
+your end position is safe.
 
 ---
 
-[^1]: If discussed with the party, subsequent stacks can be [cheesed for LB](https://ucob.guide/general/lbgen/) too.
+[^1]: If discussed with the party, subsequent stacks can be [cheesed for
+    LB](https://ucob.guide/general/lbgen/) too.

--- a/src/pages/twin.mdx
+++ b/src/pages/twin.mdx
@@ -118,7 +118,7 @@ Most parties will usually hit the next HP threshold after the Death Sentence or 
 - **Liquid Hells** - A set of 5x puddles, baited sequentially on the targeted player  
 Each puddle is a moderately-sized circle which applies <BuffDebuff name="Burns" img={burns} />, a lethal DoT,
 to any players who stand in the puddle for too long.  
-The targeted player is any single player between the radius of about 10-25 yalms. If there are multiple valid
+The targeted player is any single player that has a distance of at least 10 yalms from the boss. If there are multiple valid
 targets, a random player within the valid radius is chosen as the target for a single Liquid Hell.
 
 <ImageWrapper img={hatchmarker} alt="The Hatch and its respective marker" classdiv="mt-8"/>
@@ -154,7 +154,7 @@ Likewise, the Twister in this set will happen during the resolution of the Hatch
     - Plummet  
 </Card>
 
-- **Liquid Hells (random)** - Same as Liquid Hells, but instead of a random target within a preset range, it is
+- **Liquid Hells (random)** - Same as Liquid Hells, but instead of a person past a certain range, it is
 a random single target for all 5 puddles.  
   
   
@@ -193,6 +193,6 @@ into the Neurolink directly towards the Hatch in this phase.
 For the Generate + Twister combo, Twister will usually go off before the orb reaches you. Make sure you drop
 the twister outside of the Neurolink to ensure your end position is safe.
 
-&nbsp;
+---
 
 [^1]: If discussed with the party, subsequent stacks can be [cheesed for LB](https://ucob.guide/general/lbgen/) too.

--- a/src/pages/twin.mdx
+++ b/src/pages/twin.mdx
@@ -7,7 +7,7 @@ show_toc: false
 
 import Notification from '@/components/mdx/Notification.astro'
 import Button from '@/components/mdx/Button.astro'
-import BuffDebuff from '@/components/mdx/BuffDebuff.astro'
+import Status from '@/components/mdx/Status.astro'
 import Card from '@/components/mdx/Card.astro'
 import NASpecific from '@/components/mdx/NASpecific.astro'
 import { YouTube } from 'astro-embed'
@@ -54,7 +54,7 @@ These HP thresholds are:
 <ImageWrapperSquare img={neurolinkpuddle} alt="Neurolink puddle" classdiv="mt-8"/>
 **Neurolink** - Small puddle that is dropped under the center of Twintania's hitbox
 upon hitting a HP threshold  
-When a player steps into the Neurolink, the player gets a <BuffDebuff
+When a player steps into the Neurolink, the player gets a <Status
 name="Neurolink" img={neurolink} /> debuff, which reduces damage done by
 approximately 90% and healing done by approximately 10%. This debuff will be
 required to resolve the **Generate** mechanic explained later in this page.  
@@ -103,9 +103,9 @@ party) will stay out of this initial stack. Subsequent Fireball stacks should be
 stacked with as many people as possible.[^1]
   
 - **Death Sentence** - Tankbuster (Forced tankswap) which inflicts
-a <BuffDebuff name="Slashing Resistance Down II" img={slashing} /> on the target  
+a <Status name="Slashing Resistance Down II" img={slashing} /> on the target  
 Forced swap as Twintania's autos are slashing type. If the player that currently
-has the <BuffDebuff name="Slashing Resistance Down II" img={slashing} /> takes
+has the <Status name="Slashing Resistance Down II" img={slashing} /> takes
 an auto, they will take lethal damage.  
 
 Most parties will usually hit the next HP threshold after the Death Sentence or
@@ -125,7 +125,7 @@ Most parties will usually hit the next HP threshold after the Death Sentence or
 
 - **Liquid Hells** - A set of 5x puddles, baited sequentially on the targeted
   player  
-Each puddle is a moderately-sized circle which applies <BuffDebuff name="Burns"img={burns} />,
+Each puddle is a moderately-sized circle which applies <Status name="Burns"img={burns} />,
 a lethal DoT, to any players who stand in the puddle for too long.  
 The targeted player is any single player that has a distance of at least 10
 yalms from the boss. If there are multiple valid targets, a random player within
@@ -139,15 +139,15 @@ An orb is also referred to as a **Hatch**. *In this phase*, only DPS players can
 get marked for a Hatch. The number of players marked is determined by the number
 of Neurolinks that are currently on the arena.  
 When an orb is intercepted, the orb will explode and deal lethal damage to
-players in the immediate vicinity who do not have the <BuffDebuff name="Neurolink" img={neurolink} />
+players in the immediate vicinity who do not have the <Status name="Neurolink" img={neurolink} />
 debuff, attained from standing in a Neurolink. The people in the vicinity of the
-explosion who survive will get <BuffDebuff name="Mana Hypersensitivity" img={manahyper} />
+explosion who survive will get <Status name="Mana Hypersensitivity" img={manahyper} />
 for 16 seconds, making any Hatch-related damage lethal during the duration of
-the debuff with or without the <BuffDebuff name="Neurolink" img={neurolink} />
+the debuff with or without the <Status name="Neurolink" img={neurolink} />
 debuff.   
 If the person who intercepted the orb dies, usually when they do not have the
-<BuffDebuff name="Neurolink" img={neurolink} />, the orb will further explode,
-dealing lethal raidwide damage and applying <BuffDebuff name="Damage Down"
+<Status name="Neurolink" img={neurolink} />, the orb will further explode,
+dealing lethal raidwide damage and applying <Status name="Damage Down"
 img={damagedown} /> to any surviving players. The same result will occur when
 nobody intercepts the orb when 10 seconds have passed since the end of the
 Generate cast.  
@@ -195,7 +195,7 @@ shield or mitigation.
 ### DPS
 #### Hatches
 <ImageWrapperSquare img={hatchresolve} alt="Hatch resolution from the side" />
-Since the <BuffDebuff name="Neurolink" img={neurolink} /> debuff reduces damage
+Since the <Status name="Neurolink" img={neurolink} /> debuff reduces damage
 done by the player, minimizing the amount of time spent in the Neurolink to
 resolve Hatches is ideal. However, due to the way snapshots and latency work, it
 is recommended to **walk into the Neurolink from the side** instead of walking

--- a/src/styles/components/status.scss
+++ b/src/styles/components/status.scss
@@ -1,0 +1,6 @@
+.status {
+    display: inline;
+    max-inline-size: 1em;
+    vertical-align: text-bottom;
+  }
+  

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -161,9 +161,3 @@ h4 {
     @apply p-4 rounded mb-4;
   }
 }
-
-.buffdebuff {
-  display: inline;
-  max-inline-size: 1em;
-  vertical-align: text-bottom;
-}

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -18,3 +18,4 @@
 @import "./components/grid.scss";
 @import "./components/banner.scss";
 @import "./components/twitch.scss";
+@import "./components/status.scss";


### PR DESCRIPTION
Cleans up twin.mdx
- Liquid hells clarification fix
- Use separator for footnotes
- Follow recommendations from a local eslint branch
- Consistently wrap lines to improve readability
- Rename BuffDebuff to Status (pretty sure I was extremely tired when I named this originall 💀)